### PR TITLE
Smarter case check

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -17,8 +17,9 @@
   * `StartsWithTheSameCase` now is smarter when looking for words to check.
   * Removed `<` and `>` from `Brackets` defaults as `>` is often used as "arrow" (`->`) raising false positives.
   * Corrected default `KeyFormat` patter so it no longer allows digits at first position.
-  * `QuotationMarks`, `TypesettingQuotationMarks`, `WhiteCharsBeforeLinefeed` and `TrailingWhiteChars` now
-    support `comments` config item to control whenever you want comments to be scanned.
+  * `QuotationMarks`, `TypesettingQuotationMarks`, `WhiteCharsBeforeLinefeed` and `TrailingWhiteChars` now support `comments` config
+    item to control whenever you want comments to be scanned.
+  * `StartsWithTheSameCase` now handles the case where base/translation can start with a digit which should be case match.
 
 * v2.0.0 (2021-08-02)
   * Added support for config files.

--- a/docs/checks/starts-with-the-same-case.md
+++ b/docs/checks/starts-with-the-same-case.md
@@ -12,6 +12,7 @@
   * **Starts With The Same Case**
     * [Summary](#summary)
     * [Description](#description)
+    * [Important notes](#notes)
     * [Configuration file](#configuration-file)
 
 ---
@@ -40,9 +41,26 @@ key = %s 123 foo bar
 
 the words used for checking will be `Llorem` and `foo` respectively.
 
-*NOTE:* This check makes no sense for languages like Asian (i.e. Chinese, Japanese etc) and you should configure language exception
-list for `StartsWithTheSameCase` to make is skip such translations from being checked.
+`StartsWithTheSameCase` also can handle the case where either base string or translation starts with a digit which is some
+cases, depending on the languages used can qualify as matching translation as digits on front are language driven. For
+example
+
+```ini
+key = No support for 64-bit words.
+```
+
+while translator provides sentence that says `64-bit words are not supported.` which can be actually better form gramaticaly 
+in target language. In such case matching `No` from base with `words` from translation end up with "false positive". To support
+this, the `accept_digits` flag is provided and when its value is `true` (default) then sentence starting with a digit matches
+any case of the other language sentence.
+
+### Notes ###
+
+*NOTE:* This check most likely makes no sense for languages like Asian (i.e. Chinese, Japanese etc) and you should configure
+language exception list for `StartsWithTheSameCase` to make is skip such translations from being checked.
 
 ## Configuration file ##
 
-No dedicated configuration.
+| Key      | Type      | Description | Defaults |
+|----------|-----------|-------------|----------|
+| accept_digits | Boolean | If `true` sentence starting with a digit matches any case of the other string. | `true` |

--- a/docs/checks/starts-with-the-same-case.md
+++ b/docs/checks/starts-with-the-same-case.md
@@ -41,18 +41,12 @@ key = %s 123 foo bar
 
 the words used for checking will be `Llorem` and `foo` respectively.
 
-`StartsWithTheSameCase` also can handle the case where either base string or translation starts with a digit which is some
-cases, depending on the languages used can qualify as matching translation as digits on front are language driven. For
-example
-
-```ini
-key = No support for 64-bit words.
-```
-
-while translator provides sentence that says `64-bit words are not supported.` which can be actually better form gramaticaly 
-in target language. In such case matching `No` from base with `words` from translation end up with "false positive". To support
-this, the `accept_digits` flag is provided and when its value is `true` (default) then sentence starting with a digit matches
-any case of the other language sentence.
+`StartsWithTheSameCase` also can handle the case where either base string or translation starts with a digit which is some cases,
+depending on the languages used can qualify as matching translation as digits on front are language driven. For example, original
+message says `No support for 64-bit words.` while translation can be more like `64-bit words are not supported.`. These are both
+equivalent but the other form can be actually better choice for the target language. In such case matching `No` from base
+with `words` from translation end up with "false positive". To support this, the `accept_digits` flag is provided and when its value
+is `true` (default) then sentence starting with a digit matches any case of the other language sentence.
 
 ### Notes ###
 

--- a/proptool/checks/missing_translations.py
+++ b/proptool/checks/missing_translations.py
@@ -37,7 +37,7 @@ class MissingTranslations(Check):
                     del missing_keys[missing_keys.index(comm_key)]
 
         for missing_key in missing_keys:
-            report.warn(None, f'No translation: "{missing_key}"')
+            report.warn(None, 'Missing translation.', missing_key)
 
         return report
 

--- a/proptool/checks/starts_with_the_same_case.py
+++ b/proptool/checks/starts_with_the_same_case.py
@@ -66,10 +66,10 @@ class StartsWithTheSameCase(Check):
                 continue
 
             if ref_word and not trans_word:
-                report.warn(idx + 1, 'Translation contains no words starting with a letter, while original does.')
+                report.warn(idx + 1, 'Translation contains no words starting with a letter, while original does.', trans.key)
                 continue
             if not ref_word and trans_word:
-                report.warn(idx + 1, 'Base string contains no words starting with a letter, but translation does.')
+                report.warn(idx + 1, 'Base string contains no words starting with a letter, but translation does.', trans.key)
                 continue
 
             ref_first_char = ref_word[0]

--- a/proptool/checks/starts_with_the_same_case.py
+++ b/proptool/checks/starts_with_the_same_case.py
@@ -7,7 +7,7 @@
 #
 """
 
-from typing import Tuple, Union
+from typing import Dict, Tuple, Union
 
 from proptool.decorators.overrides import overrides
 from proptool.prop.items import Translation
@@ -33,7 +33,7 @@ class StartsWithTheSameCase(Check):
     def check(self, translation_file: 'PropFile', reference_file: 'PropFile' = None) -> ReportGroup:
         self.need_both_files(translation_file, reference_file)
 
-        report = ReportGroup('Sentence starts with different letter case.')
+        report = ReportGroup('First words case mismatch.')
 
         for idx, trans in enumerate(translation_file.items):
             # We care translations only for now.
@@ -50,6 +50,12 @@ class StartsWithTheSameCase(Check):
             # Skip if translation or reference string is empty.
             if ref.value.strip() == '' or trans.value.strip() == '':
                 continue
+
+            # Before we look for words, let's check for digits (if enabled)
+            if self.config['accept_digits']:
+                # Any starting digit matches "opposite" sentence's case
+                if ref.value[0].isdigit() or trans.value[0].isdigit():
+                    continue
 
             # Find first 'word' that starts with a letter.
             ref_word_idx, ref_word = self._find_word(ref.value)
@@ -80,3 +86,9 @@ class StartsWithTheSameCase(Check):
                 report.warn(idx + 1, f'Value starts with {found} character. Expected {expected}.', trans.key)
 
         return report
+
+    @overrides(Check)
+    def get_default_config(self) -> Dict:
+        return {
+            'accept_digits': True,
+        }

--- a/proptool/prop/file.py
+++ b/proptool/prop/file.py
@@ -208,7 +208,7 @@ class PropFile(object):
                 separator = tmp[1].strip()
                 val = tmp[2].lstrip()
                 if key in self.keys:
-                    duplicated_keys.error(line_number, f'Duplicated key "{key}".')
+                    duplicated_keys.error(line_number, 'Duplicated key.', key)
                     continue
 
                 self.append(Translation(key, val, separator))

--- a/tests/checks/test_starts_with_the_same_case.py
+++ b/tests/checks/test_starts_with_the_same_case.py
@@ -129,37 +129,34 @@ class TestStartsWithTheSameCase(ChecksTestCase):
 
     # #################################################################################################
 
+    def test_handling_of_unsupported_types(self) -> None:
+        self.check_skipping_blank_and_comment()
 
-def test_handling_of_unsupported_types(self) -> None:
-    self.check_skipping_blank_and_comment()
+    def test_handling_of_dangling_translation_keys(self) -> None:
+        self.check_skipping_of_dangling_keys()
 
+    def test_skipping_of_entry_items(self) -> None:
+        """
+        Checks if item is silently skipped if its value is empty string or value of reference
+        string is empty.
+        :return:
+        """
+        # generate some keys for translation file
+        cnt_min = 20
+        cnt_max = 40
+        keys = [self.get_random_string('key_') for _ in range(random.randint(cnt_min, cnt_max))]
 
-def test_handling_of_dangling_translation_keys(self) -> None:
-    self.check_skipping_of_dangling_keys()
+        ref_file = self.build_prepfile(keys, lower = True)
+        trans_file = self.build_prepfile(keys, lower = True)
 
+        # Let's clear some values in both files
+        upper_bound = 10
+        for _ in range(random.randint(1, upper_bound)):
+            ref_idx = random.randrange(len(ref_file.items))
+            ref_file.items[ref_idx].value = ''
 
-def test_skipping_of_entry_items(self) -> None:
-    """
-    Checks if item is silently skipped if its value is empty string or value of reference
-    string is empty.
-    :return:
-    """
-    # generate some keys for translation file
-    cnt_min = 20
-    cnt_max = 40
-    keys = [self.get_random_string('key_') for _ in range(random.randint(cnt_min, cnt_max))]
+            trans_idx = random.randrange(len(trans_file.items))
+            trans_file.items[trans_idx].value = ''
 
-    ref_file = self.build_prepfile(keys, lower = True)
-    trans_file = self.build_prepfile(keys, lower = True)
-
-    # Let's clear some values in both files
-    upper_bound = 10
-    for _ in range(random.randint(1, upper_bound)):
-        ref_idx = random.randrange(len(ref_file.items))
-        ref_file.items[ref_idx].value = ''
-
-        trans_idx = random.randrange(len(trans_file.items))
-        trans_file.items[trans_idx].value = ''
-
-    # We expect no problems.
-    self.check(trans_file, ref_file)
+        # We expect no problems.
+        self.check(trans_file, ref_file)

--- a/tests/checks/test_starts_with_the_same_case.py
+++ b/tests/checks/test_starts_with_the_same_case.py
@@ -85,6 +85,7 @@ class TestStartsWithTheSameCase(ChecksTestCase):
             ('%s statistics', '123 statystyki %s'),
             ('%s 123 Statistics', 'Statystyki %s'),
         ]
+        self.checker.config['accept_digits'] = False
         self._do_scan_test(tests, 0)
 
     def test_fault_special_cases(self) -> None:
@@ -99,6 +100,7 @@ class TestStartsWithTheSameCase(ChecksTestCase):
             # Base has words, translation does not.
             ('Some words here', '123 123 123'),
         ]
+        self.checker.config['accept_digits'] = False
         self._do_scan_test(tests, 1)
 
     def test_no_alpha_words(self) -> None:
@@ -108,38 +110,56 @@ class TestStartsWithTheSameCase(ChecksTestCase):
             # No real words. This should be skipped silently.
             ('3434 3434 34', '123 123 123'),
         ]
+        self.checker.config['accept_digits'] = False
         self._do_scan_test(tests)
 
     # #################################################################################################
 
-    def test_handling_of_unsupported_types(self) -> None:
-        self.check_skipping_blank_and_comment()
+    def test_opening_digits(self) -> None:
+        tests = [
+            ('Upper', '12345 lower'),
+            ('12345 Upper', 'lower'),
+            ('12345 Upper', '345345 lower'),
+        ]
+        self.checker.config['accept_digits'] = False
+        self._do_scan_test(tests, exp_warnings = 1)
 
-    def test_handling_of_dangling_translation_keys(self) -> None:
-        self.check_skipping_of_dangling_keys()
+        self.checker.config['accept_digits'] = True
+        self._do_scan_test(tests)
 
-    def test_skipping_of_entry_items(self) -> None:
-        """
-        Checks if item is silently skipped if its value is empty string or value of reference
-        string is empty.
-        :return:
-        """
-        # generate some keys for translation file
-        cnt_min = 20
-        cnt_max = 40
-        keys = [self.get_random_string('key_') for _ in range(random.randint(cnt_min, cnt_max))]
+    # #################################################################################################
 
-        ref_file = self.build_prepfile(keys, lower = True)
-        trans_file = self.build_prepfile(keys, lower = True)
 
-        # Let's clear some values in both files
-        upper_bound = 10
-        for _ in range(random.randint(1, upper_bound)):
-            ref_idx = random.randrange(len(ref_file.items))
-            ref_file.items[ref_idx].value = ''
+def test_handling_of_unsupported_types(self) -> None:
+    self.check_skipping_blank_and_comment()
 
-            trans_idx = random.randrange(len(trans_file.items))
-            trans_file.items[trans_idx].value = ''
 
-        # We expect no problems.
-        self.check(trans_file, ref_file)
+def test_handling_of_dangling_translation_keys(self) -> None:
+    self.check_skipping_of_dangling_keys()
+
+
+def test_skipping_of_entry_items(self) -> None:
+    """
+    Checks if item is silently skipped if its value is empty string or value of reference
+    string is empty.
+    :return:
+    """
+    # generate some keys for translation file
+    cnt_min = 20
+    cnt_max = 40
+    keys = [self.get_random_string('key_') for _ in range(random.randint(cnt_min, cnt_max))]
+
+    ref_file = self.build_prepfile(keys, lower = True)
+    trans_file = self.build_prepfile(keys, lower = True)
+
+    # Let's clear some values in both files
+    upper_bound = 10
+    for _ in range(random.randint(1, upper_bound)):
+        ref_idx = random.randrange(len(ref_file.items))
+        ref_file.items[ref_idx].value = ''
+
+        trans_idx = random.randrange(len(trans_file.items))
+        trans_file.items[trans_idx].value = ''
+
+    # We expect no problems.
+    self.check(trans_file, ref_file)


### PR DESCRIPTION
`StartsWithTheSameCase` now handles the case where base/translation can start with a digit which should be case match.